### PR TITLE
[FIX] config/nginx.conf: http -> https

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -17,25 +17,34 @@ http {
 
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
-
+    # Enable SSL session caching for improved performance
+    ssl_session_cache shared:ssl_session_cache:5m;
+    ssl_session_timeout 24h; # time which sessions can be re-used.
+    # Because the proper rotation of session ticket encryption key is
+    # not yet implemented in Nginx, we should turn this off for now.
+    ssl_session_tickets off;
+    # Default size is 16k, reducing it can improve performance slightly.
+    ssl_buffer_size 8k;
     # Gzip Settings
 
     gzip on;
 
     # http redirects to https
     server {
-        listen 80;
-        # Strict Transport Security
-        add_header Strict-Transport-Security max-age=2592000;
-        rewrite ^/.*$ https://$host$request_uri? permanent;
+        listen 80 default_server;
+        server_name _;
+        return 301 https://$host$request_uri;
     }
 
     charset utf-8;
 
     server {
         # server port and name
-        listen 443 ssl;
-
+        listen 443 ssl http2;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Frame-Options sameorigin;
+        add_header X-Content-Type-Options nosniff;
+        add_header X-Xss-Protection "1; mode=block";
         # Specifies the maximum accepted body size of a client request,
         # as indicated by the request header Content-Length.
         client_max_body_size 200m;
@@ -44,10 +53,13 @@ http {
         keepalive_timeout 60;
         ssl_certificate /etc/ssl/nginx/domain.bundle.crt;
         ssl_certificate_key /etc/ssl/nginx/domain.key;
-
-        # limit ciphers
-        ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA';
-        ssl_protocols TLSv1.2;
+        # Using this to faster verify validity of certificate.
+        ssl_stapling on;
+        ssl_stapling_verify on;
+        # Using this Google DNS to not default to the server’s DNS default.
+        resolver 8.8.4.4 8.8.8.8;
+        ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:ECDHE-RSA-AES128-GCM-SHA256:AES256+EECDH:DHE-RSA-AES128-GCM-SHA256:AES256+EDH:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
+        ssl_protocols TLSv1.2 TLSv1.3;
         ssl_prefer_server_ciphers on;
         ssl_dhparam /etc/ssl/certs/dhparam.pem;
 


### PR DESCRIPTION
http redirect to https was done incorrectly and would cause issues, when
application would try to redirect to another page, where it would not
redirect to https then.

On top of that, refactored nginx.conf to be up to date and use some
security and performance improvements.